### PR TITLE
bugfix: fixes docker tar bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM alpine:3.6
 MAINTAINER felix.buenemann@gmail.com
 
 ARG DEIS_WORKFLOW_CLI_VERSION=v2.18.0
-RUN apk add --no-cache bash curl git jq openssh-client \
+RUN apk add --no-cache bash curl git jq openssh-client libarchive-tools \
+ && ln -sf $(which bsdtar) $(which tar) \
  && curl -fsSLO https://raw.githubusercontent.com/deis/deis.io/gh-pages/deis-cli/install-v2.sh \
  && bash install-v2.sh $DEIS_WORKFLOW_CLI_VERSION \
  && mv deis /usr/bin/ \


### PR DESCRIPTION
Hi Felix!

This PR should fix the issue documented in https://github.com/coreos/bugs/issues/1095, which sometimes breaks our docker ci builds, since our node_modules are being unpacked with `tar`.
Could you please merge it, so we can test it in our newest projects?

~ Jay